### PR TITLE
Little refactor: move function byte_to_field_array to helpers module

### DIFF
--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -4,7 +4,7 @@ use ark_ff::Field;
 use ark_r1cs_std::{prelude::Boolean, uint8::UInt8, R1CSVar, ToBitsGadget};
 use ark_relations::r1cs::ConstraintSystemRef;
 use log::debug;
-use simpleworks::gadgets::traits::BitwiseOperationGadget;
+use simpleworks::gadgets::{traits::BitwiseOperationGadget, ConstraintF};
 
 pub mod traits;
 
@@ -79,4 +79,15 @@ pub fn debug_constraint_system_status<F: Field>(
         matrix.a_num_non_zero + matrix.b_num_non_zero + matrix.c_num_non_zero
     );
     Ok(())
+}
+
+pub fn byte_to_field_array(byte: u8) -> Vec<ConstraintF> {
+    let mut ret = vec![];
+
+    for i in 0_i32..8_i32 {
+        let bit = (byte & (1 << i)) != 0;
+        ret.push(crate::Fr::from(bit));
+    }
+
+    ret
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,14 +44,14 @@ pub mod helpers;
 pub mod ops;
 
 use anyhow::{anyhow, Result};
-use ark_bls12_377::Fr;
+pub use ark_bls12_377::Fr;
 use ark_ff::Field;
 use ark_r1cs_std::{
     prelude::{AllocVar, EqGadget},
     uint8::UInt8,
 };
 use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
-use helpers::traits::ToAnyhow;
+use helpers::{byte_to_field_array, traits::ToAnyhow};
 pub use simpleworks::marlin::generate_rand;
 pub use simpleworks::marlin::serialization::deserialize_proof;
 use simpleworks::{
@@ -151,17 +151,6 @@ pub fn verify_encryption(
         proof,
         &mut simpleworks::marlin::generate_rand(),
     )
-}
-
-fn byte_to_field_array(byte: u8) -> Vec<ConstraintF> {
-    let mut ret = vec![];
-
-    for i in 0_i32..8_i32 {
-        let bit = (byte & (1 << i)) != 0;
-        ret.push(Fr::from(bit));
-    }
-
-    ret
 }
 
 pub fn synthesize_keys(plaintext_length: usize) -> Result<(ProvingKey, VerifyingKey)> {


### PR DESCRIPTION
`byte_to_field_array` is a helper function so I moved to helpers module in order to simplify `lib.rs` file.